### PR TITLE
Use manual widget boot by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To use the plugin, just add plugin bundle script to the page and setup the playe
 ```html
 <script src="https://cdnapisec.kaltura.com/p/2302901/embedPlaykitJs/uiconf_id/50617632"></script>
 <!--Kaltura player-->
-<script src="https://cdn.annoto.net/playkit-plugin/latest/plugin.js"></script>
+<script src="https://cdn.annoto.net/playkit-plugin/latest/plugin.js?auto_boot=1"></script>
 <!--PlayKit Annoto plugin-->
 <div id="kaltura_player_541994816" style="width: 100%; height: 560px;"></div>
 
@@ -57,6 +57,7 @@ To use the plugin, just add plugin bundle script to the page and setup the playe
             // set the clientId, if not provided, Annoto will load in demo mode
             annoto: {
                 // clientId: 'eyJhbGciOiJIUzI1NiJ9.ZjU4MTMy...',
+                // manualBoot: true, // to manualy boot the widget or remove auto_boot=1 from the script src
             },
         }
     };
@@ -66,6 +67,7 @@ To use the plugin, just add plugin bundle script to the page and setup the playe
     // To use the annoto api, use the 'annoto' service:
 
     const annotoService = kalturaPlayer.getService('annoto');
+    // annotoService.boot(); manual boot
     annotoService.getApi().then((api) => {
         console.info('api: ', api);
     });

--- a/src/annoto.tsx
+++ b/src/annoto.tsx
@@ -2,7 +2,6 @@ import {
     IConfig,
     IAnnotoApi,
     Annoto as AnnotoMain,
-    IPlayerConfig,
     IWidgetConfig,
 } from '@annoto/widget-api';
 import {
@@ -27,6 +26,7 @@ const h = (KalturaPlayer.ui as any).h;
 declare const Annoto: AnnotoMain;
 
 export class PlaykitAnnotoPlugin extends (KalturaPlayer as any).BasePlugin implements IAnnotoPlaykitPlugin {
+    static AUTO_BOOT = false;
     readonly config!: IAnnotoPlaykitPluginConfig;
     readonly player!: IPlaykitPlayer;
     readonly logger!: KalturaPlayerTypes.Logger;
@@ -68,7 +68,7 @@ export class PlaykitAnnotoPlugin extends (KalturaPlayer as any).BasePlugin imple
         this.player.registerService('annoto', this.service);
 
         this.init().then(() => {
-            if (manualBoot === false) {
+            if (manualBoot === false || (PlaykitAnnotoPlugin.AUTO_BOOT === true && manualBoot !== true)) {
                 return this.boot();
             } else {
                 this.logger.info('skip automatic boot');

--- a/src/annoto.tsx
+++ b/src/annoto.tsx
@@ -68,7 +68,7 @@ export class PlaykitAnnotoPlugin extends (KalturaPlayer as any).BasePlugin imple
         this.player.registerService('annoto', this.service);
 
         this.init().then(() => {
-            if (!manualBoot) {
+            if (manualBoot === false) {
                 return this.boot();
             } else {
                 this.logger.info('skip automatic boot');

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -8,12 +8,17 @@
     <title>
         <%- htmlWebpackPlugin.options.title %>
     </title>
+    <style>
+        .kaltura-player .playkit-floating-container {
+            overflow: visible;
+        }
+    </style>
 </head>
 
 <body>
     <h3>Annoto Kaltura Playkit Plugin</h3>
 
-    <div id="kaltura_player_541994816" style="width: calc(100% - 350px); height: 560px;"></div>
+    <div class="kaltura-player" id="kaltura_player_541994816" style="width: calc(100% - 350px); height: 560px;"></div>
     <script src="https://cdnapisec.kaltura.com/p/2302901/embedPlaykitJs/uiconf_id/50617632"></script>
     <!-- <script src="https://raw.githack.com/kaltura/playkit-js-ui-managers/master/dist/playkit-ui-managers.js"></script> -->
     
@@ -42,7 +47,7 @@
             const kalturaPlayer = KalturaPlayer.setup(config);
             kalturaPlayer.loadMedia({ entryId: '1_lnx34lum' });
             const annotoService = kalturaPlayer.getService('annoto');
-
+            annotoService.boot();
             annotoService.getApi().then((api) => {
                 console.info('api: ', api);
             });

--- a/src/interfaces/plugin.interfaces.ts
+++ b/src/interfaces/plugin.interfaces.ts
@@ -12,9 +12,8 @@ export interface IAnnotoPlaykitPluginConfig extends Partial<IConfig> {
      */
     bootstrapUrl?: string;
     /**
-     * if set to true, boot widget manually using the PlaykitAnnotoService.boot() method
-     * by default widget boot is done automatically imideatly after plugin script is loaded
-     * @default false
+     * if set to false, boot widget automatically with the configuration provided to the plugin via the player configuration
+     * @default true
      */
     manualBoot?: boolean;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,5 +8,14 @@ export { IAnnotoPlaykitPluginConfig, IAnnotoPlaykitPlugin } from './interfaces';
 export const VERSION = BUILD_ENV.version;
 export const NAME = BUILD_ENV.name;
 
+try {
+    const queryParamas = new URL((document.currentScript as HTMLScriptElement)?.src || '').searchParams;
+    
+    const autoBoot = queryParamas.get('auto_boot');
+    if (autoBoot === 'true' || autoBoot === '1') {
+        PlaykitAnnotoPlugin.AUTO_BOOT = true;
+    }
+} catch (err) {}
+
 const pluginName: string = 'annoto';
 KalturaPlayer.core.registerPlugin(pluginName, PlaykitAnnotoPlugin);


### PR DESCRIPTION
Today the default is automatic boot, this PR makes it manual by default to provide more control to the user of this plugin and not worry about race conditions.