### PR TITLE
Fix css selector to work for v2-v7 redirect when used in KMS

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -44,7 +44,7 @@
     }
 }
 
-.nnk-widget.nnk-setup.player-v7 {
+.nnk-widget.nnk-setup {
     #mediaContainer {
         #wrapper.video {
             overflow: visible;


### PR DESCRIPTION
the Kaltura v2-v7 redirect does not update wrapper classes and still has v2 instead of v7, so don't rely on it in css